### PR TITLE
Add support for hexadecimal number (e.g. 0xff) (fixes #19)

### DIFF
--- a/test/hex_numbers.pl
+++ b/test/hex_numbers.pl
@@ -1,0 +1,8 @@
+
+q :- A = 0x10, B = 16, A = B.
+
+(1/0x10)::r.
+
+query(q). % outcome: 1
+
+query(r). % outcome: 0.0625


### PR DESCRIPTION
Updates parser to support hexadecimal numbers: 0xff, 0x0F, 0xabC.
These are translated directly to regular int.
