### PR TITLE
Extend query(True) and custom weights

### DIFF
--- a/problog/constraint.py
+++ b/problog/constraint.py
@@ -185,7 +185,7 @@ class ConstraintAD(Constraint):
             ws = []
             for n in self.nodes:
                 pos, neg = weights.get(n, (semiring.one(), semiring.one()))
-                weights[n] = (pos, semiring.one())
+                weights[n] = (pos, semiring.ad_negate(pos, neg))
                 ws.append(pos)
 
             name = Term('choice', Constant(self.group[0]), Term('e'), Term('null'), *self.group[1])
@@ -196,7 +196,7 @@ class ConstraintAD(Constraint):
             except InvalidValue:
                 raise InvalidValue('Sum of annotated disjunction weigths exceeds acceptable value', location=self.location)
                 # TODO add location
-            weights[self.extra_node] = (complement, semiring.one())
+            weights[self.extra_node] = (complement, semiring.ad_negate(complement, semiring.one()))
 
     def copy(self, rename=None):
         if rename is None:

--- a/problog/evaluator.py
+++ b/problog/evaluator.py
@@ -147,6 +147,32 @@ class Semiring(object):
         """Handle weight for deterministically false."""
         return self.zero(), self.one()
 
+    def to_evidence(self, pos_weight, neg_weight, sign):
+        """
+        Converts the pos. and neg. weight (internal repr.) of a literal into the case where the literal is evidence.
+        Note that the literal can be a negative atom regardless of the given sign.
+
+        :param pos_weight: The current positive weight of the literal.
+        :param neg_weight: The current negative weight of the literal.
+        :param sign: Denotes whether the literal or its negation is evidence. sign > 0 denotes the literal is evidence,
+            otherwise its negation is evidence. Note: The literal itself can also still be a negative atom.
+        :returns: A tuple of the positive and negative weight as if the literal was evidence.
+            For example, for probability, returns (self.one(), self.zero()) if sign else (self.zero(), self.one())
+        """
+        return (self.one(), self.zero()) if sign > 0 else (self.zero(), self.one())
+
+    def ad_negate(self, pos_weight, neg_weight):
+        """
+        Negation in the context of an annotated disjunction. e.g. in a probabilistic context for 0.2::a ; 0.8::b,
+        the negative label for both a and b is 1.0 such that model {a,-b} = 0.2 * 1.0 and {-a,b} = 1.0 * 0.8.
+        For a, pos_weight would be 0.2 and neg_weight could be 0.8. The returned value is 1.0.
+        :param pos_weight: The current positive weight of the literal (e.g. 0.2 or 0.8). Internal representation.
+        :param neg_weight: The current negative weight of the literal (e.g. 0.8 or 0.2). Internal representation.
+        :return: neg_weight corrected based on the given pos_weight, given the ad context (e.g. 1.0). Internal
+        representation.
+        """
+        return self.one()
+
 
 class SemiringProbability(Semiring):
     """Implementation of the semiring interface for probabilities."""
@@ -440,7 +466,7 @@ class Evaluator(object):
         """Set value for evidence node.
 
         :param index: index of evidence node
-        :param value: value of evidence
+        :param value: value of evidence. True if the evidence is positive, False otherwise.
         """
         raise NotImplementedError('abstract method')
 

--- a/problog/test/test_evaluator.py
+++ b/problog/test/test_evaluator.py
@@ -18,12 +18,14 @@ limitations under the License.
 import unittest
 
 from problog.program import PrologString
-from problog.formula import LogicFormula
+from problog.formula import LogicFormula, pn_weight
 from problog import get_evaluatable
 from problog.evaluator import SemiringProbability
 from problog.logic import Term
 
 # noinspection PyBroadException
+from problog.test.test_system import SemiringProbabilityNSPCopy
+
 try:
     from pysdd import sdd
     has_sdd = True
@@ -75,10 +77,29 @@ class TestEvaluator(unittest.TestCase):
         results = kc.evaluate(semiring=semiring, weights=weights)
         self.assertEqual(0.1, results[a])
 
+        # with custom weights
+        weights = {a: pn_weight(0.1, 0.1)}
+        results = kc.evaluate(semiring=semiring, weights=weights)
+        self.assertEqual(0.5, results[a])
+
         # with custom weights based on index
         weights = {kc.get_node_by_name(a) : 0.2}
         results = kc.evaluate(semiring=semiring, weights=weights)
         self.assertEqual(0.2, results[a])
+
+        # Testing with weight on node 0 (True)
+        weights = {0: 0.3, a: pn_weight(0.1, 0.1)}
+        results = kc.evaluate(semiring=semiring, weights=weights)
+        self.assertEqual(0.5, results[a])
+
+        # Testing query on node 0 (True)
+        class TestSemiringProbabilityIgnoreNormalize(SemiringProbabilityNSPCopy):
+            def normalize(self, a, z):
+                return a
+
+        weights = {0: pn_weight(0.3, 0.7), a: pn_weight(0.1, 0.1)}
+        results = kc.evaluate(index=0, semiring=TestSemiringProbabilityIgnoreNormalize(), weights=weights)
+        self.assertEqual(0.06, results)
 
 
 if __name__ == '__main__' :


### PR DESCRIPTION
- When semiring.is_nsp(): query(True) now correctly computes WMC(Theory). For now, SDD and FSDD rely on ExplicitSDD for this.
- Custom weights support has been extended to allow both positive and negative weights e.g; {a: pn_weight(0.1,0.1)}.
- d-DNNF's weight dict has been changed to be the same as the SDD's.
- Semiring extended with to_evidence(..) and ad_negate(..) for more user flexibility. Default implementation is consistent with previous behavior.