### PR TITLE
fix: toDot => to_dot

### DIFF
--- a/debug/engine.py
+++ b/debug/engine.py
@@ -55,7 +55,7 @@ def test(filename, debug=None, trace=None):
     print(target)
 
     with open("engine_debug.dot", "w") as f:
-        print(target.toDot(), file=f)
+        print(target.to_dot(), file=f)
 
 
 if __name__ == "__main__":

--- a/problog/web/server_debug.py
+++ b/problog/web/server_debug.py
@@ -161,7 +161,7 @@ def run_ground(model):
 
         handle, filename = tempfile.mkstemp(".dot")
         with open(filename, "w") as f:
-            f.write(formula.toDot())
+            f.write(formula.to_dot())
         print(formula)
         result = subprocess.check_output(["dot", "-Tsvg", filename]).decode("utf-8")
         content_type = "application/json"

--- a/step-by-step.py
+++ b/step-by-step.py
@@ -73,7 +73,7 @@ def main(filename, with_dot, knowledge):
 
     if dotprefix != None:
         with open(dotprefix + "gp.dot", "w") as f:
-            print(gp.toDot(), file=f)
+            print(gp.to_dot(), file=f)
 
     print("\n=== Acyclic Ground Program ===")
     with Timer("acyclic"):
@@ -82,7 +82,7 @@ def main(filename, with_dot, knowledge):
 
     if dotprefix != None:
         with open(dotprefix + "agp.dot", "w") as f:
-            print(gp.toDot(), file=f)
+            print(gp.to_dot(), file=f)
 
     if knowledge == "sdd":
         print("\n=== SDD compilation ===")
@@ -90,7 +90,8 @@ def main(filename, with_dot, knowledge):
             nnf = SDD.createFrom(gp)
 
         if dotprefix != None:
-            nnf.saveSDDToDot(dotprefix + "sdd.dot")
+            with open(dotprefix + "sdd.dot", "w") as f:
+                print(nnf.sdd_to_dot(None), file=f)
 
     else:
         print("\n=== Conversion to CNF ===")
@@ -103,7 +104,7 @@ def main(filename, with_dot, knowledge):
 
     if dotprefix != None:
         with open(dotprefix + "nnf.dot", "w") as f:
-            print(nnf.toDot(), file=f)
+            print(nnf.to_dot(), file=f)
 
     print("\n=== Evaluation result ===")
     with Timer("evaluate"):


### PR DESCRIPTION
When I ran `python step-by-step.py tmp.dl --with-dot` I found there were some call errors.

```
Traceback (most recent call last):
  File "path/problog/step-by-step.py", line 126, in <module>
    main(**vars(args))
  File "path/problog/step-by-step.py", line 76, in main
    print(gp.toDot(), file=f)
          ^^^^^^^^
AttributeError: 'LogicFormula' object has no attribute 'toDot'. Did you mean: 'to_dot'?
```

Besides, `saveSDDToDot` doesn't exist.
```
Traceback (most recent call last):
  File "path/problog/step-by-step.py", line 126, in <module>
    main(**vars(args))
  File "path/problog/step-by-step.py", line 93, in main
    nnf.saveSDDToDot(dotprefix + "sdd.dot")
    ^^^^^^^^^^^^^^^^
AttributeError: 'SDD' object has no attribute 'saveSDDToDot'
```