### PR TITLE
Fix unsatisfiable nested conjunctions reported as successful

### DIFF
--- a/problog/eval_nodes.py
+++ b/problog/eval_nodes.py
@@ -814,6 +814,11 @@ class EvalAnd(EvalNode):
                 all_complete, complete_actions = self.complete()
             else:
                 all_complete, complete_actions = False, []
+            if target_node == NODE_FALSE:
+                # The conjunction is unsatisfiable, so there is no proof to report.
+                # Reporting it would also confuse a parent conjunction, which uses
+                # 'source is None' to tell apart the results of its two conjuncts.
+                return all_complete, complete_actions
             if all_complete:
                 return True, self.notifyResult(result, target_node, is_last=True)
             else:

--- a/test/00_nested_conjunction.pl
+++ b/test/00_nested_conjunction.pl
@@ -1,0 +1,24 @@
+%Expected outcome:
+% flat 0
+% nested 0
+% nested_left 0
+% nested_right 0
+% consistent 0.12
+
+% Regression test for GitHub issue #145: a parenthesized (i.e. left-nested)
+% conjunction that is unsatisfiable was reported as if it succeeded.
+
+0.2::a.
+0.6::c.
+
+flat :- \+ c, c, a.
+nested :- ((\+ c, c), a).
+nested_left :- (c, \+ c), a.
+nested_right :- a, (\+ c, c).
+consistent :- (a, c).
+
+query(flat).
+query(nested).
+query(nested_left).
+query(nested_right).
+query(consistent).


### PR DESCRIPTION
Fixes #145.

## The bug

```prolog
0.2::a.
0.6::c.

q :- ((\+ c, c), a).   % q: 0.2   <- wrong
q :- \+ c, c, a.       % q: 0.0   <- correct
```

Parentheses are not the problem — the parser handles them fine. The difference is nesting direction: `,` is right-associative, so the flat body parses as `,(\+c, ,(c, a))` while the parenthesized one is left-nested, `,(,(\+c, c), a)`.

## Root cause

`EvalAnd` distinguishes a result arriving from its *first* conjunct from one arriving from its *second* by testing `source is None`, where `source` is the ground node of the first conjunct, passed along as the call `identifier`. But `NODE_FALSE` is also `None` (`problog/eval_nodes.py:19`).

For the left-nested body, the inner `,(\+c, c)` grounds through `add_and`, which detects the opposite literals and returns `FALSE`/`None` (`problog/formula.py:848`). `EvalAnd` propagated that result anyway — unlike `EvalNot`, which already guards with `if or_node != NODE_FALSE`, and `results_to_actions`, which guards with `if target_node != NODE_FALSE`. The outer `EvalAnd` then received it, launched `a` with `identifier=None`, and when `a` came back read `source is None` as "another result from the first conjunct" — re-calling `a`, conjoining it with itself, and yielding `0.2`.

Only an unsatisfiable *left* nested conjunct triggers it. Confirmed across variants before the fix:

| body | before | after | expected |
|---|---|---|---|
| `\+ c, c, a` | 0 | 0 | 0 |
| `(\+ c, c), a` | **0.2** | 0 | 0 |
| `(c, \+ c), a` | **0.2** | 0 | 0 |
| `a, (\+ c, c)` | 0 | 0 | 0 |
| `(a, c), \+ c` | 0 | 0 | 0 |
| `(\+ c, \+ c), a` | 0.08 | 0.08 | 0.08 |
| `(a, a), c` | 0.12 | 0.12 | 0.12 |

## Fix

`EvalAnd.new_result` no longer reports a result whose ground node is `NODE_FALSE`; it forwards only the completion signal. That is semantically correct on its own — an unsatisfiable ground conjunction is not a proof — and it removes the ambiguity, bringing `EvalAnd` in line with `EvalNot` and `results_to_actions`.

## Testing

Added `test/00_nested_conjunction.pl` covering the flat form, both nestings, and a consistent control case.

Full suite before the new test: 278 passed, 1 xfailed, 2053 subtests. System + engine tests re-run with it included: 117 passed, 1628 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvF573692TaGAMbxjBsMsT
