### PR TITLE
Hash the whole term, and walk ground lists in Python

### DIFF
--- a/problog/extern.py
+++ b/problog/extern.py
@@ -232,9 +232,13 @@ class problog_export_raw(problog_export):
                 # result is always a list of tuples
                 try:
                     transformed = []
+                    n = len(self.input_arguments)
                     for i, r in enumerate(result):
                         r = self._convert_output(r, self.input_arguments[i])
-                        if bound & (1 << i):
+                        # _extract_callmode puts the bit of argument i at
+                        # n - i - 1, so indexing it with i swaps the arguments
+                        # around and unifies the wrong ones.
+                        if bound & (1 << (n - i - 1)):
                             r = unify_value(r, args[i], {})
                         transformed.append(r)
                     from .engine_stack import Context, get_state

--- a/problog/library/lists.pl
+++ b/problog/library/lists.pl
@@ -39,10 +39,16 @@
     select_weighted/4
 ]).
 
-% member(X,L)
-%  X is an element from list L
-memberchk(X,[X|_]).
-memberchk(X,[Y|T]) :- X \= Y, memberchk(X,T).
+% memberchk(X,L)
+%  X unifies with an element of list L.  Succeeds at most once.
+%  A ground list is walked in Python: doing it with the clauses of
+%  memberchk_search/2 costs a tabled call per element, which dominates any
+%  program that carries a list along as a set of what it has already visited.
+memberchk(X,L) :- memberchk_ground(X,L).
+memberchk(X,L) :- ground_list(L,false), memberchk_search(X,L).
+
+memberchk_search(X,[X|_]).
+memberchk_search(X,[Y|T]) :- X \= Y, memberchk_search(X,T).
 
 
 % member(X,L)

--- a/problog/library/lists.py
+++ b/problog/library/lists.py
@@ -1,7 +1,48 @@
 from collections import defaultdict
 
-from problog.extern import problog_export_nondet
-from problog.logic import term2list
+from problog.engine_unify import UnifyError, unify_value
+from problog.extern import problog_export, problog_export_nondet, problog_export_raw
+from problog.logic import Term, is_ground, term2list
+
+
+def _ground_list(term):
+    """The elements of term when it is a ground list, None otherwise."""
+    if not is_ground(term):
+        return None
+    try:
+        return term2list(term, deep=False)
+    except ValueError:  # not a fixed length list
+        return None
+
+
+@problog_export("+term", "-term", functor="ground_list")
+def _ground_list_check(term):
+    """Whether memberchk_ground/2 applies to term, as 'true' or 'false'."""
+    return Term("true") if _ground_list(term) is not None else Term("false")
+
+
+@problog_export_raw("+term", "+term", functor="memberchk_ground")
+def _memberchk_ground(element, term, **kwargs):
+    """memberchk/2 for a ground list, fails for anything else.
+
+    Walking a list with the clauses in lists.pl costs one tabled call per
+    element, which dominates any program that carries a list along as a set of
+    what it has already visited.  The list being ground is what makes doing it
+    here equivalent: unifying with one of its elements can only bind variables
+    of the element being looked up, never anything inside the list.
+    """
+    elements = _ground_list(term)
+    if elements is None:
+        return []
+    if element is None:  # unbound, so it unifies with the first element
+        return [(elements[0], term)] if elements else []
+    for e in elements:
+        try:
+            unify_value(element, e, {})
+        except UnifyError:
+            continue
+        return [(e, term)]
+    return []
 
 
 @problog_export_nondet("+term", "-term", "-list")

--- a/problog/logic.py
+++ b/problog/logic.py
@@ -761,45 +761,46 @@ class Term(object):
 
     def __hash__(self):
         if self.__hash is None:
-            # CG
-            list_hash = [self.__functor, self.__arity, self._list_length()]
-
-            def get_arg_len(a):
-                if isinstance(a, list):
-                    return len(a)
-                elif isinstance(a, Term):
-                    return a._list_length()
+            # The hash has to look at the whole term.  Truncating it (e.g. after a
+            # fixed number of list elements) makes every longer term that shares a
+            # prefix collide, which degrades the goal tables of the engine into
+            # linear scans over __eq__.  Hashing a deep term recursively overflows
+            # the Python stack, so the subterm hashes are filled in bottom-up with
+            # an explicit stack.  They are cached per term, so a term built on top
+            # of already hashed subterms still only costs O(arity).
+            todo = [(self, False)]
+            while todo:
+                term, expanded = todo.pop()
+                if term.__hash is not None:
+                    continue
+                elif expanded:
+                    term.__hash = term._compute_hash()
                 else:
-                    return 1
-
-            def add_to_hash(a):
-                if isinstance(a, list):
-                    list_hash.extend(a)
-                else:
-                    list_hash.append(a)
-
-            # We only consider restricted number of args, because arbitrary numbers lead to RecursionError
-            if self.__args is not None and len(self.__args) > 0:
-                cut_off_len = 10
-
-                # include first arg
-                total_list_len = get_arg_len(self.__args[0])
-                add_to_hash(self.__args[0])
-
-                # include more args?
-                if cut_off_len > total_list_len:
-                    for arg in self.__args[1:10]:  # Only consider first 10 args (bit arbitrary)
-                        arg_length = get_arg_len(arg)
-                        if total_list_len + arg_length <= cut_off_len:
-                            total_list_len += arg_length
-                            add_to_hash(arg)
-                        else:
-                            break
-
-            self.__hash = hash(tuple(list_hash))
-
-            # self.__hash = hash((self.__functor, self.__arity, firstarg, self._list_length()))
+                    todo.append((term, True))
+                    todo.extend((a, False) for a in term._hash_subterms())
         return self.__hash
+
+    def _hash_subterms(self):
+        """The subterms whose hash is needed to hash this term.
+
+        Arity zero terms are skipped: they have nothing nested and some of them
+        (:class:`Constant`, :class:`Var`, :class:`Object`) hash themselves.
+        """
+        for arg in self.__args:
+            # An argument can be a list of terms, e.g. the heads of an
+            # AnnotatedDisjunction.
+            args = arg if type(arg) == list else (arg,)
+            for a in args:
+                if isinstance(a, Term) and a.__arity and a.__hash is None:
+                    yield a
+
+    def _compute_hash(self):
+        # \+x and not(x) are equal (see __eq__) so they may not differ here.
+        functor = "\\+" if isinstance(self, Not) else self.__functor
+        key = [functor, self.__arity]
+        for arg in self.__args:
+            key.append(tuple(arg) if type(arg) == list else arg)
+        return hash(tuple(key))
 
     def __lshift__(self, body):
         return Clause(self, body)

--- a/problog/test/library/test_lists.py
+++ b/problog/test/library/test_lists.py
@@ -1,0 +1,97 @@
+"""
+Part of the ProbLog distribution.
+
+Copyright 2026 KU Leuven, DTAI Research Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import re
+import unittest
+
+from problog import get_evaluatable
+from problog.program import PrologString
+
+
+def evaluate(program):
+    result = get_evaluatable().create_from(PrologString(program)).evaluate()
+    return {str(k): v for k, v in result.items()}
+
+
+class TestLibLists(unittest.TestCase):
+    def test_memberchk(self):
+        """A ground list takes the Python path in lists.py."""
+        res = evaluate(
+            """
+            :- use_module(library(lists)).
+            hit             :- memberchk(2, [1,2,3]).
+            miss            :- memberchk(9, [1,2,3]).
+            empty           :- memberchk(a, []).
+            binds_element   :- memberchk(f(X), [g(1), f(7), f(8)]), X =:= 7.
+            takes_the_first :- memberchk(X, [4,5]), X =:= 4.
+            nested          :- memberchk([1,2], [[3],[1,2]]).
+            not_a_list      :- memberchk(a, notalist).
+            improper_list   :- memberchk(a, [x,y|z]).
+            query(hit). query(miss). query(empty). query(binds_element).
+            query(takes_the_first). query(nested). query(not_a_list).
+            query(improper_list).
+        """
+        )
+        self.assertEqual(
+            {
+                "hit": 1.0,
+                "miss": 0.0,
+                "empty": 0.0,
+                "binds_element": 1.0,
+                "takes_the_first": 1.0,
+                "nested": 1.0,
+                "not_a_list": 0.0,
+                "improper_list": 0.0,
+            },
+            res,
+        )
+
+    def test_memberchk_non_ground(self):
+        """A list that is not ground falls back on the clauses in lists.pl.
+
+        The bindings it makes are the reason it has to: they reach into the
+        list, and into a variable shared between both arguments.
+        """
+        res = evaluate(
+            """
+            :- use_module(library(lists)).
+            open_list(L)   :- memberchk(a, L).
+            open_tail(T)   :- memberchk(a, [b|T]).
+            partial(L)     :- memberchk(a, [x,y|_]), L = done.
+            in_the_list(X) :- memberchk(a, [X,b]).
+            shared(X, E)   :- memberchk(X, [E,b]).
+            query(open_list(_)). query(open_tail(_)). query(partial(_)).
+            query(in_the_list(_)). query(shared(_,_)).
+        """
+        )
+        self.assertEqual([1.0] * 5, sorted(res.values()))
+        # The numbering of the free variables depends on how many the program
+        # has used before, so compare the shape of the answers.
+        self.assertEqual(
+            [
+                "in_the_list(a)",
+                "open_list([a | _])",
+                "open_tail([a | _])",
+                "partial(done)",
+                "shared(_,_)",
+            ],
+            sorted(re.sub(r"X\d+", "_", name) for name in res),
+        )
+        # memberchk(X, [E,b]) unifies X and E with each other, so the two
+        # arguments have to come back as the same variable.
+        shared = [name for name in res if name.startswith("shared(")][0]
+        self.assertEqual(*shared[len("shared(") : -1].split(","))

--- a/problog/test/test_logic.py
+++ b/problog/test/test_logic.py
@@ -1,6 +1,16 @@
 import unittest
 
-from problog.logic import And, AnnotatedDisjunction, Or, Clause, Not, Term, Var
+from problog.logic import (
+    And,
+    AnnotatedDisjunction,
+    Constant,
+    Or,
+    Clause,
+    Not,
+    Term,
+    Var,
+    list2term,
+)
 
 
 class TestLogic(unittest.TestCase):
@@ -149,3 +159,42 @@ class TestLogic(unittest.TestCase):
         self.assertTrue(c4 == c5)
         self.assertFalse(c4 == c6)
         self.assertFalse(c4 == c7)
+
+    def test_hash_matches_equality(self):
+        equal_terms = [
+            (Not("\\+", Term("a")), Not("not", Term("a"))),
+            (And(Term("a"), Term("b")), Term("a") & Term("b")),
+            (Term("a") & Term("b") & Term("c"), Term.from_string("a,b,c.")),
+            (Term.from_string("a:-b."), Clause(Term("a"), Term("b"))),
+            (
+                AnnotatedDisjunction([Term("a"), Term("b")], Term("c")),
+                AnnotatedDisjunction([Term("a"), Term("b")], Term("c")),
+            ),
+            (Term("p", Var("X")), Term("p", Var("X"))),
+            (
+                list2term([Constant(i) for i in range(50)]),
+                list2term([Constant(i) for i in range(50)]),
+            ),
+        ]
+        for t1, t2 in equal_terms:
+            self.assertEqual(t1, t2)
+            msg = "%s and %s are equal but hash differently" % (t1, t2)
+            self.assertEqual(hash(t1), hash(t2), msg)
+
+    def test_hash_uses_whole_term(self):
+        # Hashing only a prefix of a term made every longer term sharing that
+        # prefix collide, which degrades the goal tables of the engine into
+        # linear scans over Term.__eq__ (issue #78).
+        lists = [list2term([Constant(0)] * 20 + [Constant(i)]) for i in range(100)]
+        self.assertEqual(len(lists), len(set(map(hash, lists))))
+
+        args = [Term("f", *([Constant(0)] * 20 + [Constant(i)])) for i in range(100)]
+        self.assertEqual(len(args), len(set(map(hash, args))))
+
+    def test_hash_deep_term(self):
+        # Hashing may not recurse: these are deeper than the recursion limit.
+        deep_list = list2term([Constant(i) for i in range(50000)])
+        nested = Constant(0)
+        for i in range(50000):
+            nested = Term("f", nested)
+        self.assertNotEqual(hash(deep_list), hash(nested))

--- a/test/extern_lib.py
+++ b/test/extern_lib.py
@@ -1,4 +1,5 @@
-from problog.extern import problog_export_nondet, problog_export
+from problog.extern import problog_export, problog_export_nondet, problog_export_raw
+from problog.logic import Term
 
 
 @problog_export("+str", "+str", "-str")
@@ -24,3 +25,14 @@ def int_plus_times(a, b):
 @problog_export_nondet("+int", "+int", "-int")
 def int_between(a, b):
     return list(range(a, b + 1))
+
+
+@problog_export_raw("+term", "+term")
+def pair(a, b, **kwargs):
+    """Answers pair(one, two) and nothing else.
+
+    A raw export receives every argument, bound or not, and the ones the
+    caller had bound are unified with what it answers, so a call naming any
+    other value has to fail.
+    """
+    return [(Term("one"), Term("two"))]

--- a/test/extern_raw_test.pl
+++ b/test/extern_raw_test.pl
@@ -1,0 +1,25 @@
+%Expected outcome:
+% both_bound 1
+% first_free 1
+% second_free 1
+% both_free 1
+% first_wrong 0
+% second_wrong 0
+% first_wrong_second_free 0
+% first_free_second_wrong 0
+:- use_module('extern_lib.py').
+
+% pair/2 answers pair(one, two), so a bound argument naming anything else
+% has to make the call fail, whichever argument it is.
+both_bound :- pair(one, two).
+first_free :- pair(X, two), X == one.
+second_free :- pair(one, X), X == two.
+both_free :- pair(X, Y), X == one, Y == two.
+first_wrong :- pair(nope, two).
+second_wrong :- pair(one, nope).
+first_wrong_second_free :- pair(nope, _).
+first_free_second_wrong :- pair(_, nope).
+
+query(both_bound). query(first_free). query(second_free). query(both_free).
+query(first_wrong). query(second_wrong).
+query(first_wrong_second_free). query(first_free_second_wrong).


### PR DESCRIPTION
Addresses the second method of #78, where grounding a transitive closure that
carries a visited-list ran for over a week without finishing.

### The bug

`Term.__hash__` stopped after ten list elements, so any two longer terms
sharing that prefix hashed identically:

```python
>>> a = list2term([Constant(0)] * 20 + [Constant(1)])
>>> b = list2term([Constant(0)] * 20 + [Constant(2)])
>>> hash(a) == hash(b)
True
```

The engine keys its goal tables on the call arguments, so a program threading a
list through its recursion drops thousands of colliding keys into one bucket and
every table lookup becomes a linear scan over `Term.__eq__` — which is what
@VincentDerk found at the top of the profile in that issue. Grounding was
quadratic in the number of tabled goals.

The cut-off was there because hashing a long list recursively overflows the
Python stack. The hashes of the subterms are now filled in bottom-up with an
explicit stack; they are cached per term, so a term built on already hashed
subterms still costs O(arity) and nothing has to be left out.

### Commits

| | |
|---|---|
| `57b4a73` | hash the whole term |
| `ece5427` | `memberchk/2` walks a ground list in Python instead of costing one tabled call per element, keeping the clauses for the cases where the bindings reach into the list |
| `fe96e5f` | `problog_export_raw` unifies the wrong argument from arity two upwards — **unrelated to #78**, found on the way, happy to move it out |

### Effect

| | before | after |
|---|---|---|
| `problog_transitive_method2.txt` from #78 | ran a week, unfinished | 52 min |
| 17 of its 19 edges | 1128s | 56s |
| hashing 20 000 cells of a growing list | 100.5s | 0.049s |
| hashing flat and nested terms | — | 8-16% faster |

What is left in that program is inherent: the number of `knows/3` calls is the
number of edge-simple trails from the start node — 665 at four nodes, 2 648 191
at five — each carrying a different list, so tabling can never merge two of
them. Per-step cost measures the same as on a program with no lists at all.

Suite passes: 303 tests, 2074 subtests. New tests cover the hash (discrimination,
equality/hash agreement, deep terms), `memberchk/2` semantics including the
non-ground cases that must fall back on the clauses, and the raw-external fix.

Based on #150 because that is where the branch was cut from; there is no file
overlap, so it rebases onto master cleanly if you would rather have it
standalone. #78 will need closing by hand — a closing keyword here would not
fire, since this merges into a non-default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwfmE52z7BJmmaewvNzaVY