### PR TITLE
Accept a pair of bounds as an evaluation result

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,10 @@ Intermediate bugfixes and speed improvements are not listed.
         - MaxSAT solvers that are not installed are reported as unavailable,
           rather than failing inside the call to the solver.
         - 'problog mpe --solver scip' no longer fails with a TypeError.
+        - 'problog explain --web' produces JSON again. It serialised a
+          dictionary keyed by Term, which json rejects, so it failed before
+          writing anything. The task also reports a k-best result that is a
+          pair of bounds rather than an exact value, instead of failing on it.
 
     macOS:
         - dsharp is now a universal binary and runs on Apple Silicon.

--- a/problog/evaluator.py
+++ b/problog/evaluator.py
@@ -462,8 +462,15 @@ class Evaluatable(ProbLogObject):
         the program it was given produces results that are silently wrong,
         such as a probability above one. Semirings that do not constrain their
         results are unaffected.
+
+        Not every evaluator answers with a single value: KBestEvaluator
+        returns a (lower, upper) pair whenever its search converges on bounds
+        instead of reaching an exact value, and each bound is a result of the
+        semiring in its own right. Check them one by one, so that a pair does
+        not reach result_in_domain() and fail its comparison with a TypeError.
         """
-        if not semiring.result_in_domain(value):
+        values = value if isinstance(value, tuple) else (value,)
+        if not all(semiring.result_in_domain(v) for v in values):
             raise CompilationError(
                 "Evaluating '%s' produced %s, which is not a valid result for "
                 "this semiring. The knowledge compiler most likely returned a "

--- a/problog/tasks/explain.py
+++ b/problog/tasks/explain.py
@@ -30,6 +30,18 @@ from ..program import PrologFile
 from ..util import init_logger, format_dictionary
 
 
+def _round_probability(value):
+    """Round a result of the explain task for JSON output.
+
+    KBestFormula answers with a (lower, upper) pair whenever its search
+    converges on bounds rather than reaching an exact value, so a result is
+    not always a float. A pair becomes a two element list.
+    """
+    if isinstance(value, tuple):
+        return [round(v, 8) for v in value]
+    return round(value, 8)
+
+
 def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("filename")
@@ -60,10 +72,17 @@ def main(argv):
         result["proofs"] = explanation
         result["results"] = results
         if args.web:
-            result["probabilities"] = [
-                (str(k), round(v, 8)) for k, v in results.items()
+            # json cannot serialise `results` as it stands: it is keyed by
+            # Term, which raises "keys must be str". Serialise a copy and
+            # leave `result` alone for callers that use main()'s return value.
+            web_result = dict(result)
+            web_result["results"] = {
+                str(k): _round_probability(v) for k, v in results.items()
+            }
+            web_result["probabilities"] = [
+                (str(k), _round_probability(v)) for k, v in results.items()
             ]
-            print(json.dumps(result), file=out)
+            print(json.dumps(web_result), file=out)
         else:
             print("Transformed program", file=out)
             print("-------------------", file=out)

--- a/problog/test/test_tasks.py
+++ b/problog/test/test_tasks.py
@@ -1,7 +1,11 @@
+import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from problog.kbest import KBestEvaluator
 from problog.logic import Constant, Term, Not
 from problog.tasks import map, explain, time1, bayesnet, mpe, ground, probability
 from problog.tasks import exit_code, run_task
@@ -88,6 +92,59 @@ class TestTasks(unittest.TestCase):
         # Test result
         results = result["results"]
         self.assertAlmostEqual(0.8, results[Term("someHeads")], delta=1e6)
+
+    def test_explain_accepts_bounds_from_kbest(self):
+        """KBestEvaluator answers with a (lower, upper) pair rather than a
+        float whenever its search converges on bounds instead of reaching an
+        exact value. The domain check compared that pair against 0.0 and 1.0
+        and died with a TypeError, so whether 'problog explain' worked came
+        down to how the k-best search happened to terminate."""
+        file_name = test_folder / "tasks" / "some_heads.pl"
+        with patch.object(KBestEvaluator, "evaluate", return_value=(0.75, 0.85)):
+            result = explain.main([str(file_name)])
+
+        self.assertTrue(result["SUCCESS"])
+        self.assertEqual((0.75, 0.85), result["results"][Term("someHeads")])
+
+    def test_explain_rejects_bounds_outside_the_domain(self):
+        """A bound above one still has to be caught: the check is there to
+        report a knowledge compiler that returned the wrong formula."""
+        file_name = test_folder / "tasks" / "some_heads.pl"
+        with patch.object(KBestEvaluator, "evaluate", return_value=(0.75, 1.5)):
+            result = explain.main([str(file_name)])
+
+        self.assertFalse(result["SUCCESS"])
+
+    def _explain_web_json(self, file_name):
+        """Run the explain task with --web and parse what it wrote."""
+        handle, path = tempfile.mkstemp(suffix=".json")
+        os.close(handle)
+        try:
+            explain.main([str(file_name), "--web", "-o", path])
+            with open(path) as out:
+                return json.load(out)
+        finally:
+            os.unlink(path)
+
+    def test_explain_web_output_is_json(self):
+        """--web serialised a dictionary keyed by Term, which json refuses
+        with "keys must be str", so it never produced any output at all."""
+        payload = self._explain_web_json(test_folder / "tasks" / "some_heads.pl")
+
+        self.assertTrue(payload["SUCCESS"])
+        self.assertAlmostEqual(0.8, payload["results"]["someHeads"], places=6)
+        self.assertEqual([["someHeads", 0.8]], payload["probabilities"])
+
+    def test_explain_web_output_with_bounds(self):
+        """A pair reaches the web output as a two element list; rounding it
+        as if it were a float raised a TypeError."""
+        file_name = test_folder / "tasks" / "some_heads.pl"
+        with patch.object(KBestEvaluator, "evaluate", return_value=(0.75, 0.85)):
+            payload = self._explain_web_json(file_name)
+
+        self.assertTrue(payload["SUCCESS"])
+        self.assertEqual([0.75, 0.85], payload["results"]["someHeads"])
+        self.assertEqual([["someHeads", [0.75, 0.85]]], payload["probabilities"])
 
     def check_probability(self, expected, result):
         self.assertTrue(result[0])


### PR DESCRIPTION
The wheel build on master went red on `wheel manylinux_2_28_x86_64` (run 34391849736), on one test out of 298:

```
TypeError: '<=' not supported between instances of 'float' and 'tuple'
  problog/evaluator.py:242 in result_in_domain
```

`KBestEvaluator.evaluate` does not always answer with a single value — it returns a `(lower, upper)` pair whenever its search converges on bounds instead of reaching an exact value (`problog/kbest.py:168` and `:178`). The domain check from `b384520` assumes a scalar and compares the pair against `0.0` and `1.0`.

So whether `problog explain` worked came down to how the k-best search happened to terminate. The same commit passed on all six platforms in #159 and failed on one job on master, which is why it read as flakiness.

It is also a **regression against 2.2.10**: that release has no domain check at all — I checked the published wheel — and returned the bounds happily.

Reproduces in one line:

```python
>>> SemiringProbability().result_in_domain((0.3, 0.4))
TypeError: '<=' not supported between instances of 'float' and 'tuple'
```

### The fix

Check each bound separately. A bound above one is still rejected — catching a knowledge compiler that returned a formula which does not represent the program is what the check is for.

### Also: `explain --web`

While here, `problog explain --web` has never worked, in this release **or in 2.2.10** — the two files differ only in where `result["SUCCESS"] = False` is assigned. It put `results` into the payload keyed by `Term`, and json refuses those:

```
TypeError: keys must be str, int, float, bool or None, not Term
```

so the task failed before writing anything. It now serialises a copy with string keys and turns a pair of bounds into a two element list instead of calling `round()` on the tuple. The value `main()` returns is unchanged, still keyed by `Term`, for programmatic callers.

### Tests

Four added. Three fail without the fix; the fourth pins that an out-of-domain bound is still rejected, so the fix cannot drift into accepting anything. Full suite: 307 passed, 1 xfailed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SEeiKwokYoRArvuwxy5tN