### PR TITLE
Bump the GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,11 +20,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build the solver binaries

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -51,7 +51,7 @@ jobs:
             image: quay.io/pypa/musllinux_1_2_aarch64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -71,7 +71,7 @@ jobs:
           '
           sudo chown -R "$(id -u):$(id -g)" .
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -82,7 +82,7 @@ jobs:
                  --platform-tag ${{ matrix.plat }} --remove dist/*.whl
           ls -l dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.plat }}
           path: dist/*.whl
@@ -109,11 +109,11 @@ jobs:
             tests: problog/test -k "ddnnf or dsharp or mpe or maxsat"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -170,7 +170,7 @@ jobs:
                  --platform-tag ${{ matrix.plat }} --remove dist/*.whl
           ls -l dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.plat }}
           path: dist/*.whl
@@ -179,8 +179,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # No submodule: the sdist is pure Python and carries no binaries.
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip build
@@ -193,7 +193,7 @@ jobs:
             echo "::error::sdist contains solver binaries; it must stay pure"
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -203,13 +203,13 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
       - run: ls -l dist
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Supersedes #154, #155, #156, #157 and #158 by taking all five in one commit. They edit the same two workflow files, so merged one at a time each merge puts the other four out of date again, and branch protection requires them to be current — five rebase-and-wait cycles for what is one change.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `pypa/gh-action-pypi-publish` | v1.4.2 | v1.14.2 |

The first three move off Node 20, which the runners have been warning about on every job.

### What I checked on the two that touch publishing

**`download-artifact` v8** still accepts `merge-multiple`, which the publish job depends on to collect seven artifacts into one `dist/` — confirmed against v8's own `action.yml`. Its breaking change is that a digest mismatch now fails the download instead of passing it on, which is what you want for release artifacts.

**`gh-action-pypi-publish`** was pinned to `27b31702`, which is **v1.4.2, from February 2021**. In v1.14.2 `user` and `password` are still supported, and `attestations` — true by default since v1.11 — is explicitly ignored when a password is set, since attestations require Trusted Publishing:

```
ATTESTATIONS_WITHOUT_TP_WARNING="::warning title=attestations input ignored::\
The workflow was run with the 'attestations: true' input, but an explicit \
password was also set, disabling Trusted Publishing. ..."
```

So it warns rather than failing, no `id-token: write` is needed, and the token flow is unchanged.

### Why before the release rather than after

The publish job has never run in its current shape. The last successful publish — 2.2.10, March 2026 — went through a single `deploy` job that ran `python -m build` and uploaded straight from it, with no artifacts involved at all; #150 replaced that wholesale. 2.3.0 is also the first release whose metadata carries a PEP 639 `License-Expression` rather than the old `License:` field. Meeting that on a code path that has never executed is better done with a maintained action than a six year old pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SEeiKwokYoRArvuwxy5tN